### PR TITLE
Add Toggle Option to Disable and Enable Naming LogiX Nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -441,3 +441,5 @@ $RECYCLE.BIN/
 
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 
+# Symlinked Libraries
+SymlinkedLibraries/**/*.dll

--- a/Build.ps1
+++ b/Build.ps1
@@ -1,5 +1,6 @@
 
 param (
+    [string] $NeosDir = "C:\Program Files (x86)\Steam\steamapps\common\NeosVR\",
     [switch] $NoRun = $false,
     [switch] $ReleaseMode = $false
 )
@@ -21,7 +22,6 @@ if($NoRun)
 }
 
 $dir = Split-Path -Path (Get-Location) -Leaf
-$NeosDir = "C:\Program Files (x86)\Steam\steamapps\common\NeosVR\"
 $NeosExe = "$NeosDir\Neos.exe"
 $AssemblyLocation = "$(Get-Location)\bin\$BinaryLocation\net4.7.2\$dir.dll"
 $LogFolder = "$NeosDir\Logs\"

--- a/Nodentify.cs
+++ b/Nodentify.cs
@@ -19,6 +19,9 @@ public class Nodentify : NeosMod
     [AutoRegisterConfigKey]
     private static ModConfigurationKey<double> PressDelay = new ModConfigurationKey<double>("PressDelay", "Press delay for node actions", () => 0.25);
 
+    [AutoRegisterConfigKey]
+    private static ModConfigurationKey<bool> AllowModifiedNodeNames = new ModConfigurationKey<bool>("AllowModifiedNodeNames", "Allow LogiX node names to be edited and to show custom names", () => true);
+
     static void press(IButton b, ButtonEventData d) { _then = Engine.Current.WorldManager.FocusedWorld.Time.WorldTime; }
 
     static void hold(IButton b, ButtonEventData d, TextEditor e)
@@ -67,7 +70,7 @@ public class Nodentify : NeosMod
     {
         static void Postfix(LogixNode __instance, UIBuilder __result, Slot root, float minWidth = 0f, float minHeight = 0f)
         {
-            if (__result.Current == null)
+            if (__result.Current == null || !Config!.GetValue(AllowModifiedNodeNames))
                 return;
 
             Text? t =  __result.Current.GetComponent<Text>();
@@ -137,6 +140,9 @@ public class Nodentify : NeosMod
                 refButton.LocalReleased += release;
                 return;
             }
+
+            if (!Config!.GetValue(AllowModifiedNodeNames))
+                return;
             Slot s = __instance.Slot.FindChild((s) => s.Tag == "Nodentify.Node.AlteredText", 25);
             if (s == null)
                 return;

--- a/Nodentify.sln
+++ b/Nodentify.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nodentify", "Nodentify.csproj", "{722A2927-0133-4624-BAB4-D81592A93F21}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{722A2927-0133-4624-BAB4-D81592A93F21}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{722A2927-0133-4624-BAB4-D81592A93F21}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{722A2927-0133-4624-BAB4-D81592A93F21}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{722A2927-0133-4624-BAB4-D81592A93F21}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {625CFEFD-93F1-4610-A6BD-5635D4C2723D}
+	EndGlobalSection
+EndGlobal

--- a/SymlinkedLibraries/0Harmony.dll
+++ b/SymlinkedLibraries/0Harmony.dll
@@ -1,1 +1,0 @@
-../../../../../../../Program Files (x86)/Steam/steamapps/common/NeosVR/0Harmony.dll

--- a/SymlinkedLibraries/BaseX.dll
+++ b/SymlinkedLibraries/BaseX.dll
@@ -1,1 +1,0 @@
-../../../../../../../Program Files (x86)/Steam/steamapps/common/NeosVR/Neos_Data/Managed/BaseX.dll

--- a/SymlinkedLibraries/CSCore.dll
+++ b/SymlinkedLibraries/CSCore.dll
@@ -1,1 +1,0 @@
-../../../../../../../Program Files (x86)/Steam/steamapps/common/NeosVR/Neos_Data/Managed/CSCore.dll

--- a/SymlinkedLibraries/CodeX.dll
+++ b/SymlinkedLibraries/CodeX.dll
@@ -1,1 +1,0 @@
-../../../../../../../Program Files (x86)/Steam/steamapps/common/NeosVR/Neos_Data/Managed/CodeX.dll

--- a/SymlinkedLibraries/FrooxEngine.dll
+++ b/SymlinkedLibraries/FrooxEngine.dll
@@ -1,1 +1,0 @@
-../../../../../../../Program Files (x86)/Steam/steamapps/common/NeosVR/Neos_Data/Managed/FrooxEngine.dll

--- a/SymlinkedLibraries/NeosModLoader.dll
+++ b/SymlinkedLibraries/NeosModLoader.dll
@@ -1,1 +1,0 @@
-../../../../../../../Program Files (x86)/Steam/steamapps/common/NeosVR/Libraries/NeosModLoader.dll

--- a/SymlinkedLibraries/Symlink the library references here.md
+++ b/SymlinkedLibraries/Symlink the library references here.md
@@ -1,0 +1,12 @@
+# The following libraries should be symlinked in this folder:
+
+0Harmony.dll
+BaseX.dll
+CodeX.dll
+CSCore.dll
+FrooxEngine.dll
+NeosModLoader.dll
+
+# To symlink a DLL in Windows, use the following PowerShell cmdlet:
+
+New-Item -ItemType SymbolicLink -Path "<Path to Symlink in Repo>" -Target "<Path to DLL in Neos' folder>"


### PR DESCRIPTION
# Main Feature
Added the ability to enable and disable the LogiX node renaming feature (also known as commenting). This is a feature request for those that want to open reference arrows only.

# Reop Chores
* Updated the Symlinked Libraries doc to state which libraries need to be symlinked. 
* Slightly changed the build script to include the NeosDir as an optional argument; the default value is still the same as in the previous build script.